### PR TITLE
Support passing blocks to strategy methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* support passing blocks to strategy methods
+
+
 ## [2.0.0] - 2023-01-17
 ### Changed
 * switch CI to github actions
@@ -28,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * fix after wrapper ordering bug [PR#6](https://github.com/andreaseger/receptacle/pull/6)
 
 ## [0.3.0}
-### Added 
+### Added
 * add danger
 * also support higher arity methods (== method with more than one argument)
 
@@ -38,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * enable ruby 2.1+
 
 ## [0.1.1]
-## Added 
+## Added
 * add changelog, update copyright
 * add test helper method `ensure_method_delegators` to make rspec stubs/mocks work as expected
 

--- a/lib/receptacle/repo.rb
+++ b/lib/receptacle/repo.rb
@@ -6,11 +6,11 @@ module Receptacle
   module Repo
     module ClassMethods
       def mediate(method_name)
-        define_singleton_method(method_name) do |*args, **kwargs|
+        define_singleton_method(method_name) do |*args, **kwargs, &block|
           raise Errors::NotConfigured.new(repo: self) unless @strategy
 
           with_wrappers(@wrappers.dup, method_name, *args, **kwargs) do |*sub_args, **sub_kwargs|
-            strategy.new.public_send(method_name, *sub_args, **sub_kwargs)
+            strategy.new.public_send(method_name, *sub_args, **sub_kwargs, &block)
           end
         end
       end


### PR DESCRIPTION
If we pass a block while calling a strategy method. We always get `LocalJumpError: no block given (yield)`. That is because we are only passing `args` and `kwargs` when we call strategy methods. Here is a fix to pass `&block` as well.

Here is an example to re-produce this issue:

```ruby
module Strategy
  class Database
    def find(id:)
      yield(id)
    end
  end
end
```

```ruby
Repo.find(id: 1) { |a| puts(a) }
```